### PR TITLE
Simplify API

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -14,20 +14,14 @@ func RunCLI() {
 	outputFormat := flag.String("f", "png", "output file format")
 	flag.Parse()
 
-	c, err := NewConverter(
+	if err := Convert(
 		WithInputFromArgs(flag.Args()),
 		WithOutputPath(*outputPath),
 		WithOutputFormat(*outputFormat),
 		WithDensity(*density),
 		WithWidth(*width),
 		WithHeight(*height),
-	)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-
-	if err := c.ConvertAndWrite(); err != nil {
+	); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/consts.go
+++ b/consts.go
@@ -1,13 +1,14 @@
 package zpl
 
-const PDF = "pdf"
-const PNG = "png"
-const ZPL = "zpl"
+const (
+	PDF = "pdf"
+	PNG = "png"
+)
 
 func allowedDensities() []int {
 	return []int{6, 8, 12, 24}
 }
 
 func allowedOutputFormats() []string {
-	return []string{PDF, PNG, ZPL}
+	return []string{PDF, PNG}
 }

--- a/zpl.go
+++ b/zpl.go
@@ -147,6 +147,8 @@ func (conv *converter) Convert() error {
 		return err
 	}
 
+	defer converted.Close()
+
 	if _, err := io.Copy(conv.output, converted); err != nil {
 		return fmt.Errorf("failed to write output: %w", err)
 	}

--- a/zpl_integration_test.go
+++ b/zpl_integration_test.go
@@ -3,6 +3,7 @@
 package zpl_test
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
@@ -14,9 +15,32 @@ func TestConvert(t *testing.T) {
 	t.Parallel()
 
 	args := []string{"testdata/hello.zpl"}
+	output := &bytes.Buffer{}
 
-	c, err := zpl.NewConverter(
+	if err := zpl.Convert(
 		zpl.WithInputFromArgs(args),
+		zpl.WithOutputFormat(zpl.PNG),
+		zpl.WithOutput(output),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	want, err := os.Open("testdata/hello.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := output
+	if err := zplutils.CompareImages(want, got); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConvertBytes(t *testing.T) {
+	t.Parallel()
+
+	res, err := zpl.ConvertBytes(
+		[]byte("^xa^cfa,50^fo100,100^fdHello World^fs^xz"),
 		zpl.WithOutputFormat(zpl.PNG),
 	)
 	if err != nil {
@@ -28,11 +52,26 @@ func TestConvert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := c.Convert()
+	got := bytes.NewBuffer(res)
+	if err := zplutils.CompareImages(want, got); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestToPNG(t *testing.T) {
+	t.Parallel()
+
+	res, err := zpl.ToPNG([]byte("^xa^cfa,50^fo100,100^fdHello World^fs^xz"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	want, err := os.Open("testdata/hello.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := bytes.NewBuffer(res)
 	if err := zplutils.CompareImages(want, got); err != nil {
 		t.Fatal(err)
 	}

--- a/zpl_test.go
+++ b/zpl_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/kamilturek/go-zpl"
+	zpl "github.com/kamilturek/go-zpl"
 )
 
 func TestWithInput(t *testing.T) {
@@ -23,12 +23,7 @@ func TestWithInput(t *testing.T) {
 
 	want := []byte("^xa^xz")
 
-	output, err := c.Convert()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := io.ReadAll(output)
+	got, err := io.ReadAll(c.Input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,12 +47,7 @@ func TestWithInputFromArgs(t *testing.T) {
 
 	want := []byte("^xa^cfa,50^fo100,100^fdHello World^fs^xz")
 
-	output, err := c.Convert()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := io.ReadAll(output)
+	got, err := io.ReadAll(c.Input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,12 +73,7 @@ func TestInputFromArgsNoArgs(t *testing.T) {
 
 	want := []byte("^xa^xz")
 
-	output, err := c.Convert()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := io.ReadAll(output)
+	got, err := io.ReadAll(c.Input)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The package can now be used like below:
```go
zpl.ToPNG([]byte("^xa^cfa,50^fo100,100^fdHello World^fs^xz"))
zpl.ToPDF([]byte("^xa^cfa,50^fo100,100^fdHello World^fs^xz"))
```

Which are just convenience wrappers around:
```go
zpl.ConvertBytes(
    []byte("^xa^cfa,50^fo100,100^fdHello World^fs^xz"),
    WithOutputFormat(zpl.PNG)
)
zpl.ConvertBytes(
    []byte("^xa^cfa,50^fo100,100^fdHello World^fs^xz"),
    WithOutputFormat(zpl.PDF)
)
```
Which are just convenience wrappers around `zpl.Convert` that operates on buffers.