### PR TITLE
Add label size validation for Labelary API limits

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -3,6 +3,9 @@ package zpl
 const (
 	PDF = "pdf"
 	PNG = "png"
+	// MaxLabelSizeInches is the maximum label width/height accepted by the
+	// Labelary API (15 inches).
+	MaxLabelSizeInches = 15
 )
 
 func allowedDensities() []int {

--- a/errors.go
+++ b/errors.go
@@ -9,3 +9,5 @@ var ErrInvalidDensity = fmt.Errorf("invalid density: must be one of %v", allowed
 var ErrInvalidOutputFormat = fmt.Errorf("invalid output format: must be one of %v", allowedOutputFormats())
 var ErrNilInput = errors.New("nil input")
 var ErrNilOutput = errors.New("nil output")
+var ErrInvalidWidth = fmt.Errorf("invalid width: must be between 1 and %d inches", MaxLabelSizeInches)
+var ErrInvalidHeight = fmt.Errorf("invalid height: must be between 1 and %d inches", MaxLabelSizeInches)

--- a/zpl.go
+++ b/zpl.go
@@ -108,6 +108,10 @@ func WithDensity(density int) option {
 
 func WithWidth(width int) option {
 	return func(c *converter) error {
+		if width <= 0 || width > MaxLabelSizeInches {
+			return ErrInvalidWidth
+		}
+
 		c.width = width
 
 		return nil
@@ -116,6 +120,10 @@ func WithWidth(width int) option {
 
 func WithHeight(height int) option {
 	return func(c *converter) error {
+		if height <= 0 || height > MaxLabelSizeInches {
+			return ErrInvalidHeight
+		}
+
 		c.height = height
 
 		return nil

--- a/zpl_test.go
+++ b/zpl_test.go
@@ -82,3 +82,33 @@ func TestInputFromArgsNoArgs(t *testing.T) {
 		t.Fatal(diff)
 	}
 }
+
+func TestWithWidthValidation(t *testing.T) {
+	t.Parallel()
+
+	// width greater than MaxLabelSizeInches should return an error
+	_, err := zpl.NewConverter(
+		zpl.WithWidth(16),
+	)
+	if err == nil {
+		t.Fatal("expected error for width > MaxLabelSizeInches")
+	}
+	if err != zpl.ErrInvalidWidth {
+		t.Fatalf("unexpected error for width validation: %v", err)
+	}
+}
+
+func TestWithHeightValidation(t *testing.T) {
+	t.Parallel()
+
+	// height greater than MaxLabelSizeInches should return an error
+	_, err := zpl.NewConverter(
+		zpl.WithHeight(16),
+	)
+	if err == nil {
+		t.Fatal("expected error for height > MaxLabelSizeInches")
+	}
+	if err != zpl.ErrInvalidHeight {
+		t.Fatalf("unexpected error for height validation: %v", err)
+	}
+}


### PR DESCRIPTION
- Add MaxLabelSizeInches constant (15 inches max)
- Add ErrInvalidWidth and ErrInvalidHeight error variables
- Validate width/height in WithWidth() and WithHeight() functions
- Add unit tests for dimension validation
- Prevents HTTP 400 errors from exceeding Labelary's 15x15 inch limit